### PR TITLE
fix: upgrade requests and add workflow permissions

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -12,6 +12,9 @@ env:
   REGISTRY: docker.io
   IMAGE_NAME: instavm/coderunner
 
+permissions:
+  contents: read
+
 jobs:
   docker-build:
     runs-on: ubuntu-latest

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ aiofiles
 
 openai
 
-requests==2.32.4
+requests>=2.33.0
 
 mcp[cli]
 


### PR DESCRIPTION
## Summary
- Upgrades `requests` from `2.32.4` to `>=2.33.0` to resolve a known CVE (flagged by CodeQL)
- Adds explicit `permissions: contents: read` to the Docker build workflow to address the missing permissions warning

## Test plan
- [x] Verify Docker build workflow runs successfully
- [x] Confirm no dependency conflicts with `requests>=2.33.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)