### PR TITLE
Add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,12 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please report it responsibly. **Do not open a public GitHub issue.**
+
+Instead, please use one of the following methods:
+
+- **Email:** [hello@instavm.io](mailto:hello@instavm.io)
+- **GitHub Security Advisories:** Use [GitHub's private security reporting](https://github.com/instavm/coderunner/security/advisories/new) to disclose the vulnerability confidentially.
+
+We take all security reports seriously and will respond as quickly as possible. Thank you for helping keep this project and its users safe.


### PR DESCRIPTION
Adds a security policy with guidelines for responsibly reporting vulnerabilities.

- Report via email: hello@instavm.io
- Or use GitHub's private security advisory reporting
- Do not open public issues for security vulnerabilities