### PR TITLE
fix: allow resume of stopped coderunner container

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,26 @@ chmod +x install.sh
 ./install.sh
 ```
 
+### Stop and resume
+
+Stop the sandbox when you are done:
+
+```bash
+container stop coderunner
+```
+
+Resume the same sandbox later, preserving uploads, kernels, and installed packages:
+
+```bash
+container start coderunner
+```
+
+To start over with a clean sandbox, delete the container and run the installer again:
+
+```bash
+container delete coderunner && ./install.sh
+```
+
 
 ## Run Claude Code inside a Sandbox
 

--- a/install.sh
+++ b/install.sh
@@ -82,12 +82,6 @@ echo "Running: container system property set dns.domain local"
 container system property set dns.domain local
 
 
-echo "Pulling the latest image: instavm/coderunner"
-if ! container image pull instavm/coderunner; then
-    echo "❌ Failed to pull image. Please check your internet connection and try again."
-    exit 1
-fi
-
 echo "→ Ensuring coderunner assets directories…"
 ASSETS_SRC="$HOME/.coderunner/assets"
 mkdir -p "$ASSETS_SRC/skills/user"
@@ -98,14 +92,25 @@ echo "Stopping any existing coderunner container..."
 container stop coderunner 2>/dev/null || true
 sleep 2
 
+echo "Trying to resume any existing coderunner container..."
+if container start coderunner 2>/dev/null; then
+    echo "✅ Setup complete. MCP server is available at http://coderunner.local:8222/mcp"
+    exit 0
+fi
+
+echo "Pulling the latest image: instavm/coderunner"
+if ! container image pull instavm/coderunner; then
+    echo "❌ Failed to pull image. Please check your internet connection and try again."
+    exit 1
+fi
+
 # Run the command to start the sandbox container
-echo "Running: container run --name coderunner --detach --rm --cpus 8 --memory 4g instavm/coderunner"
+echo "Running: container run --name coderunner --detach --cpus 8 --memory 4g instavm/coderunner"
 if container run \
   --volume "$ASSETS_SRC/skills/user:/app/uploads/skills/user" \
   --volume "$ASSETS_SRC/outputs:/app/uploads/outputs" \
   --name coderunner \
   --detach \
-  --rm \
   --cpus 8 \
   --memory 4g \
   instavm/coderunner; then

--- a/install.sh
+++ b/install.sh
@@ -105,7 +105,7 @@ if ! container image pull instavm/coderunner; then
 fi
 
 # Run the command to start the sandbox container
-echo "Running: container run --name coderunner --detach --cpus 8 --memory 4g instavm/coderunner"
+echo "Running: container run --volume \"$ASSETS_SRC/skills/user:/app/uploads/skills/user\" --volume \"$ASSETS_SRC/outputs:/app/uploads/outputs\" --name coderunner --detach --cpus 8 --memory 4g instavm/coderunner"
 if container run \
   --volume "$ASSETS_SRC/skills/user:/app/uploads/skills/user" \
   --volume "$ASSETS_SRC/outputs:/app/uploads/outputs" \


### PR DESCRIPTION
## Summary

`install.sh` always launched the sandbox with `container run --rm`, which destroys the container on `container stop`. There was no documented or supported path to stop the sandbox and resume it later: the next `./install.sh` ran `container image pull` and `container run --rm` again, starting from a fresh state every time.

Two changes:

1. Try `container start coderunner` at the top of `install.sh`. If the container exists, resume it and exit early. If it doesn't, fall through to the pull + run path.
2. Drop `--rm` from `container run` so the sandbox survives a `container stop`.

README adds a `## Stop and resume` section documenting both paths (resume the same sandbox, or `container delete` + re-install for a clean start).

## Why this matters

#4 (filed by @mkagenius in July 2025) asks for the ability to resume coderunner after stopping it. The current install script makes that impossible by design (`--rm`). Keeping uploads, kernels, and pip-installed packages across restarts is a reasonable workflow for an MCP-served sandbox; the alternative is reinstalling deps every restart, which defeats the persistent-assets dir the installer already creates at `~/.coderunner/assets`.

Closes #4
